### PR TITLE
Remove Play Services reference

### DIFF
--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -448,7 +448,7 @@
     <string name="Enabled">Enabled</string>
     <string name="Disabled">Disabled</string>
     <string name="NotificationsService">Notifications Service</string>
-    <string name="NotificationsServiceDisableInfo">If Google Play Services are enough for you to receive notifications, you can disable Notifications Service. However we recommend you to leave it enabled to keep app running in background and receive instant notifications.</string>
+    <string name="NotificationsServiceDisableInfo">Turning off the notifications service will disable all notifications. Are you sure?</string>
     <string name="SortBy">Sort By</string>
     <string name="ImportContacts">Import Contacts</string>
     <string name="SortFirstName">First name</string>


### PR DESCRIPTION
I have changed the English NotificationsServiceDisableInfo string from "If Google Play Services are enough for you to receive notifications, you can disable Notifications Service. However we recommend you to leave it enabled to keep app running in background and receive instant notifications." to "Turning off the notifications service will disable all notifications. Are you sure?"

Discussion can be had on the issue thread #62 