### PR TITLE
Fix crash on share

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -642,15 +642,7 @@ public class LaunchActivity extends Activity implements ActionBarLayout.ActionBa
                                 }
                             }
                             String subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
-                            Pattern r = Pattern.compile("geo: ?(-?\\d+\\.\\d+),(-?\\d+\\.\\d+)(,|\\?z=)(-?\\d+)");
-                            Matcher m = r.matcher(text);
-                            if(m.find()){
-                                sendingLocation = new TLRPC.TL_messageMediaGeo();
-                                sendingLocation.geo = new TLRPC.TL_geoPoint();
-                                sendingLocation.geo.lat = Double.parseDouble(m.group(1));
-                                sendingLocation.geo._long = Double.parseDouble(m.group(2));
-                            }
-                            else if (text != null && text.length() != 0) {
+                            if (text != null && text.length() != 0) {
                                 if ((text.startsWith("http://") || text.startsWith("https://")) && subject != null && subject.length() != 0) {
                                     text = subject + "\n" + text;
                                 }


### PR DESCRIPTION
#115 If you had a picture open in the Android Gallery and clicked the Telegram button

to send it to a chat, Telegram would crash. Removing this stops it from crashing.
