### PR TITLE
Release wakelock in onPause method

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/PopupNotificationActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PopupNotificationActivity.java
@@ -1153,6 +1153,9 @@ public class PopupNotificationActivity extends Activity implements NotificationC
             chatActivityEnterView.setFieldFocused(false);
         }
         ConnectionsManager.getInstance().setAppPaused(true, false);
+		if (!wakeLock.isHeld()) {
+			wakeLock.release();
+		}
     }
 
     @Override
@@ -1232,7 +1235,6 @@ public class PopupNotificationActivity extends Activity implements NotificationC
         super.onDestroy();
         onFinish();
         if (wakeLock.isHeld()) {
-            wakeLock.release();
         }
         if (avatarImageView != null) {
             avatarImageView.setImageDrawable(null);


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Wakelock".

Wake locks are mechanisms used to control the power state of a phone. Thus, it should be closed whenever it is no longer necessary. Due to the nature of the Android app’s lifecycle, sometimes the wake lock is not properly closed. An example is releasing the wake lock in ```onDestroy()``` instead of in ```onPause()```.

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis