### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/support/widget/RecyclerView.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/support/widget/RecyclerView.java
@@ -1766,6 +1766,9 @@ public class RecyclerView extends ViewGroup implements ScrollingView, NestedScro
                 MotionEvent cancelEvent = MotionEvent.obtain(now, now,
                         MotionEvent.ACTION_CANCEL, 0.0f, 0.0f, 0);
                 onTouchEvent(cancelEvent);
+				if (cancelEvent != null) {
+					cancelEvent.recycle();
+				}
                 mLayoutFrozen = true;
                 mIgnoreMotionEventTillDown = true;
                 stopScroll();


### PR DESCRIPTION
Hi again,

This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary.

This also part of the [Android lint](http://tools.android.com/tips/lint-checks).

I think this particular case matches the description in this [book](https://books.google.pt/books?id=RuN0jb4YASwC&pg=PA857&lpg=PA857&dq=android+motionevent+recycle&source=bl&ots=u5Oq6zuVa3&sig=TKADHMzvCB_BsSDHcbEgt5S_rz8&hl=en&sa=X&ved=0ahUKEwi28_j4zq3RAhUInRQKHYefCfYQ6AEIQTAG#v=onepage&q=android%20motionevent%20recycle&f=false) (2nd paragraph).

Best,
Luis